### PR TITLE
Add runtime environment variable injection via `env-config.js`

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <title>OpenAgri-UserDashboard + TS</title>
   </head>
   <body>
+    <script src="/env-config.js"></script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -28,6 +28,15 @@ server {
     add_header                  Access-Control-Allow-Origin *;
     add_header                  Access-Control-Allow-Methods "POST, GET, OPTIONS, DELETE, PATCH";
 
+    # This location block will serve the dynamic JavaScript file.
+    # We are using Nginx's `return` directive to dynamically serve
+    # the content with the environment variables replaced at runtime.
+    location = /env-config.js {
+        default_type application/javascript;
+        add_header Cache-Control "no-store";
+        return 200 'window.env = { "VITE_API_URL": "${VITE_API_URL}" };';
+    }
+
 
     # --------------------------------------------------------------------
     # Core SPA Routing:

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -17,7 +17,7 @@ const useFetch = <FetchResponse = any>(
     const [error, setError] = useState<Error | null>(null);
 
     const { session, setSession } = useSession();
-    const apiUrl = import.meta.env.VITE_API_URL;
+    const apiUrl = window.env?.VITE_API_URL;
 
     const fetchData = async (dynamicBody = {}, dynamicHeader = {}) => {
         setLoading(true);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,7 +3,15 @@
 interface ImportMetaEnv {
     readonly VITE_API_URL: string;
   }
-  
+
   interface ImportMeta {
     readonly env: ImportMetaEnv;
   }
+
+  interface Window {
+    // This is the custom object we're adding to the window object at runtime
+    // It contains the variables we're dynamically injecting.
+    env: {
+        VITE_API_URL: string;
+    }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,6 +25,16 @@ export default defineConfig({
       globPatterns: ['**/*.{js,css,html,svg,png,ico}'],
       cleanupOutdatedCaches: true,
       clientsClaim: true,
+      // also make sure it's not pre-cached
+      globIgnores: ['**/env-config.js'],
+      // NEVER cache the runtime env file
+      runtimeCaching: [
+        {
+          urlPattern: /\/env-config\.js$/,
+          handler: 'NetworkOnly', // or 'NetworkFirst' with low cache
+        },
+      ],
+
     },
 
     devOptions: {


### PR DESCRIPTION
### Motivation

Previously, the app relied only on Vite’s `import.meta.env`, which is baked in at build time. This caused issues when deploying the same image to multiple environments. With this change:

* Environment variables are injected at runtime by Nginx.
* The React app always fetches the latest values at startup.
* PWA caching is configured to prevent stale `env-config.js`.

---

### Summary

This PR introduces a mechanism to inject environment variables at **runtime** (container start) instead of build time. This allows the dashboard to adapt to different deployment environments without rebuilding the app.

---

### Changes

* **`index.html`**

  * Added `<script src="/env-config.js"></script>` before the React entrypoint to ensure runtime variables are available before the app loads.

* **`nginx/nginx.conf`**

  * Added an exact-match `location` block for `/env-config.js`.
  * Serves a small JavaScript snippet with environment variables (currently `VITE_API_URL`).
  * Disabled caching (`Cache-Control: no-store`) to always load fresh values.

* **`src/hooks/useFetch.ts`**

  * Updated to use `window.env?.VITE_API_URL` instead of `import.meta.env.VITE_API_URL`, enabling runtime injection.

* **`src/vite-env.d.ts`**

  * Extended typings to declare `window.env` with `VITE_API_URL`.

* **`vite.config.ts`**

  * Updated PWA configuration to exclude `/env-config.js` from precaching.
  * Added runtime caching rule to always fetch `env-config.js` from the network.

---

### Testing

* Verified `/env-config.js` returns the expected `window.env` object.
* Confirmed `useFetch` picks up the correct API URL.
* Ensured `env-config.js` is not cached by service worker or browser.

---

### Caveats

Not the more robust solution but since we only pass one env variable to FE can make it work. In the future if we need more vars we may consider to export them in a json file and serve it
